### PR TITLE
Missing Fable Package Settings inside the fsproj.

### DIFF
--- a/Feliz.React.Msal/Feliz.React.Msal.fsproj
+++ b/Feliz.React.Msal/Feliz.React.Msal.fsproj
@@ -35,6 +35,10 @@
 			<NpmPackage Name="@azure/msal-react @azure/msal-browser" Version="gte 1.4.0" ResolutionStrategy="Max" />
 		</NpmDependencies>
 	</PropertyGroup>
+	 <!-- Add source files to "fable" folder in Nuget package -->
+	<ItemGroup>
+	    <Content Include="*.fsproj; **\*.fs; **\*.fsi" PackagePath="fable\" />
+	</ItemGroup>
 </Project>
 
 


### PR DESCRIPTION
Hi. Package is not working, when added to a project. That's because the sources are not part of the nuget.

Here is the fix. Thank fopr that package. Was on it, to write my own until I found yours.